### PR TITLE
refactor: Service collection in command action

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "jest -c jest.config.unit.js",
     "test:int": "jest -c jest.config.integration.js",
     "test:coverage": "npm run test -- --coverage",
-    "check": "npm run lint && npm run build && npm run test"
+    "check": "npm run lint && npm run build && npm run test:coverage"
   },
   "keywords": [
     "cli",

--- a/src/commands/commands/agile/commands/sprints/commands/create/agileSprintsCreate.test.ts
+++ b/src/commands/commands/agile/commands/sprints/commands/create/agileSprintsCreate.test.ts
@@ -1,8 +1,9 @@
 import mockFs from "mock-fs";
-import { AgileServiceFactory } from "../../../../../../../factories";
 import { CliSimulator, ModelSimulator, SimulatorAgileService } from "../../../../../../../test";
 import { Logger, UserUtils } from "../../../../../../../utils";
 import { agileSprintsCreate } from "./agileSprintsCreate";
+jest.mock("../../../../../../../factories/agileServiceFactory");
+import { AgileServiceFactory } from "../../../../../../../factories/agileServiceFactory";
 
 describe("Agile Sprints Create Command", () => {
   const cseConfigFileName = "cse.json";

--- a/src/commands/commands/agile/commands/sprints/commands/create/agileSprintsCreate.ts
+++ b/src/commands/commands/agile/commands/sprints/commands/create/agileSprintsCreate.ts
@@ -1,16 +1,16 @@
 import { Command } from "../../../../../../../extensions";
-import { AgileServiceFactory } from "../../../../../../../factories";
-import { CseCliConfig } from "../../../../../../../models";
+import { ServiceCollection } from "../../../../../../../models";
 
 export const agileSprintsCreate = new Command()
   .name("create")
   .description("Create Sprints with Agile Provider")
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  .addAction(async (options: any, config: CseCliConfig) => {
-    const { agile } = config;
-    if (!agile) {
-      throw new Error("Section agile required for this command");
+  .addAction(async (serviceCollection: ServiceCollection) => {
+    const { agileService } = serviceCollection;
+
+    if (!agileService) {
+      throw new Error("Section 'agile' must be configured for this command");
     }
-    const agileService = AgileServiceFactory.get(agile);
+
     await agileService.createSprints();
   });

--- a/src/commands/commands/agile/commands/work/commands/create/agileWorkCreate.ts
+++ b/src/commands/commands/agile/commands/work/commands/create/agileWorkCreate.ts
@@ -1,7 +1,6 @@
 import { FileConstants } from "../../../../../../../constants";
 import { Command } from "../../../../../../../extensions";
-import { AgileServiceFactory } from "../../../../../../../factories";
-import { BacklogItemTemplate, CseCliConfig } from "../../../../../../../models";
+import { BacklogItemTemplate, ServiceCollection } from "../../../../../../../models";
 import { FileUtils, Logger } from "../../../../../../../utils";
 
 export interface AgileInitializationOptions {
@@ -12,13 +11,12 @@ export const agileWorkCreate = new Command()
   .name("create")
   .description("Work Item Creation")
   .option("-f, --file <file>", "File containing backlog item template")
-  .addAction(async (options: AgileInitializationOptions, config: CseCliConfig) => {
-    const { agile: agileConfig } = config;
-    if (!agileConfig) {
-      throw new Error("Section agile is required for this operation");
+  .addAction(async (serviceCollection: ServiceCollection, options: AgileInitializationOptions) => {
+    const { agileService } = serviceCollection;
+
+    if (!agileService) {
+      throw new Error("Section 'agile' must be configured for this command");
     }
-    // Instantiate agile service from factory
-    const agileService = AgileServiceFactory.get(agileConfig);
 
     // Read agile items from provided file
     const { file } = options;

--- a/src/commands/commands/agile/commands/work/commands/template/commands/init/agileWorkTemplateInit.ts
+++ b/src/commands/commands/agile/commands/work/commands/template/commands/init/agileWorkTemplateInit.ts
@@ -1,6 +1,6 @@
 import { FileConstants } from "../../../../../../../../../constants";
 import { Command } from "../../../../../../../../../extensions";
-import { BacklogItemTemplate } from "../../../../../../../../../models";
+import { BacklogItemTemplate, ServiceCollection } from "../../../../../../../../../models";
 import { emptyBacklogItemTemplate, exampleBacklogItemTemplate } from "../../../../../../../../../samples";
 import { FileUtils } from "../../../../../../../../../utils";
 
@@ -14,7 +14,7 @@ export const agileWorkTemplateInit = new Command()
   .description("Initialize work item template")
   .option("-t, --template <template>", "Template to use for work items")
   .option("-o, --out-file <out-file>", "Output file for work item template")
-  .addAction((options: AgileWorkTemplateInitOptions) => {
+  .addAction((serviceCollection: ServiceCollection, options: AgileWorkTemplateInitOptions) => {
     // Stub for now - will fetch templates from repo
     const templates: BacklogItemTemplate[] = [exampleBacklogItemTemplate, emptyBacklogItemTemplate];
 

--- a/src/commands/commands/agile/commands/work/commands/template/commands/list/agileWorkTemplateList.test.ts
+++ b/src/commands/commands/agile/commands/work/commands/template/commands/list/agileWorkTemplateList.test.ts
@@ -22,7 +22,7 @@ describe("Agile Work Template List", () => {
     mockFs.restore();
   });
 
-  it("runs a test", async () => {
+  it("lists work item templates", async () => {
     await agileWorkTemplateList.parseAsync(CliSimulator.createArgs());
     expect(Logger.logHeader).toBeCalledWith("Work Item Templates");
     // Currently a stub for the predefined templates we have in this repo

--- a/src/commands/commands/agile/commands/work/commands/template/commands/list/agileWorkTemplateList.ts
+++ b/src/commands/commands/agile/commands/work/commands/template/commands/list/agileWorkTemplateList.ts
@@ -1,15 +1,13 @@
 import { Command } from "../../../../../../../../../extensions";
-import { BacklogItemTemplate } from "../../../../../../../../../models";
-import { emptyBacklogItemTemplate, exampleBacklogItemTemplate } from "../../../../../../../../../samples";
+import { ServiceCollection } from "../../../../../../../../../models";
 import { Logger } from "../../../../../../../../../utils";
 
 export const agileWorkTemplateList = new Command()
   .name("list")
   .description("List available work item templates")
-  .addAction(async () => {
-    // Stub for now - will fetch templates from repo
-    const templates: BacklogItemTemplate[] = [exampleBacklogItemTemplate, emptyBacklogItemTemplate];
-
+  .addAction(async (serviceCollection: ServiceCollection) => {
+    const { playbookService } = serviceCollection;
+    const templates = await playbookService.getTemplates();
     Logger.logHeader("Work Item Templates");
     templates.forEach((template) => Logger.log(template.name));
   });

--- a/src/commands/commands/playbook/commands/template/commands/copy/playbookTemplateCopy.test.ts
+++ b/src/commands/commands/playbook/commands/template/commands/copy/playbookTemplateCopy.test.ts
@@ -1,7 +1,28 @@
+import { CliSimulator } from "../../../../../../../test";
 import { playbookTemplateCopy } from "./playbookTemplateCopy";
+jest.mock("../../../../../../../services");
+import { CsePlaybookService } from "../../../../../../../services";
 
 describe("Playbook Template Copy Command", () => {
   it("contains correct number of sub-commands", () => {
     expect(playbookTemplateCopy.commands).toHaveLength(0);
+  });
+
+  it("copies a template from the playbook", async () => {
+    CsePlaybookService.prototype.downloadRepoItem = jest.fn();
+    const repoPath = "repoPath";
+    const localPath = "localPath";
+
+    await playbookTemplateCopy.parseAsync(CliSimulator.createArgs([
+      {
+        name: "--path",
+        value: repoPath,
+      },
+      {
+        name: "--out-path",
+        value: localPath,
+      }
+    ]));
+    expect(CsePlaybookService.prototype.downloadRepoItem).toBeCalledWith(repoPath, localPath);
   });
 });

--- a/src/commands/commands/playbook/commands/template/commands/copy/playbookTemplateCopy.ts
+++ b/src/commands/commands/playbook/commands/template/commands/copy/playbookTemplateCopy.ts
@@ -1,12 +1,11 @@
-import { ConfigValue } from "../../../../../../../constants";
 import { Command } from "../../../../../../../extensions";
 import { ServiceCollection } from "../../../../../../../models";
-import { Config, Logger } from "../../../../../../../utils";
 
 export interface PlaybookTemplateCopyOptions {
   path: string;
   branch: string;
   githubToken: string;
+  outPath: string;
 }
 
 export const playbookTemplateCopy = new Command()
@@ -17,13 +16,7 @@ export const playbookTemplateCopy = new Command()
   .option("-p, --path <template-path>", "Path to template within playbook repo")
   .option("-o, --out-path <out-path>", "Local path to which file will be written. Defaults to name of template file")
   .addAction(async (serviceCollection: ServiceCollection, options: PlaybookTemplateCopyOptions) => {
-    const { repoService } = serviceCollection;
-
-    const { path, branch } = options;
-
-    const playbookOwnerName: string = Config.getValue(ConfigValue.PlaybookOwnerName);
-    const playbookRepoName: string = Config.getValue(ConfigValue.PlaybookRepoName);
-
-    Logger.log(`Getting template from ${playbookOwnerName}/${playbookRepoName} at path ${path}`);
-    await repoService.downloadRepoItem(playbookOwnerName, playbookRepoName, path, branch);
+    const { playbookService } = serviceCollection;
+    const { path, outPath } = options;
+    await playbookService.downloadRepoItem(path, outPath);
   });

--- a/src/commands/commands/playbook/commands/template/commands/copy/playbookTemplateCopy.ts
+++ b/src/commands/commands/playbook/commands/template/commands/copy/playbookTemplateCopy.ts
@@ -1,8 +1,6 @@
 import { ConfigValue } from "../../../../../../../constants";
 import { Command } from "../../../../../../../extensions";
-import { RepoServiceFactory } from "../../../../../../../factories";
-import { CseCliConfig } from "../../../../../../../models";
-import { RepoServiceProvider } from "../../../../../../../services";
+import { ServiceCollection } from "../../../../../../../models";
 import { Config, Logger } from "../../../../../../../utils";
 
 export interface PlaybookTemplateCopyOptions {
@@ -18,26 +16,14 @@ export const playbookTemplateCopy = new Command()
   .option("-g, --github-token <github-token>", "GitHub personal access token")
   .option("-p, --path <template-path>", "Path to template within playbook repo")
   .option("-o, --out-path <out-path>", "Local path to which file will be written. Defaults to name of template file")
-  .addAction(async (options: PlaybookTemplateCopyOptions, config: CseCliConfig) => {
-    const { path, branch, githubToken } = options;
-    // If access token passed as option, use that over configured value
-    if (githubToken) {
-      config.github = {
-        ...config.github,
-        personalAccessToken: githubToken,
-      };
-    }
+  .addAction(async (serviceCollection: ServiceCollection, options: PlaybookTemplateCopyOptions) => {
+    const { repoService } = serviceCollection;
 
-    const { playbook, github } = config;
+    const { path, branch } = options;
 
-    const githubService = RepoServiceFactory.get({
-      providerName: RepoServiceProvider.GitHub,
-      ...github,
-    });
-
-    const playbookOwnerName: string = playbook?.playbookOwner || Config.getValue(ConfigValue.PlaybookOwnerName);
-    const playbookRepoName: string = playbook?.playbookRepo || Config.getValue(ConfigValue.PlaybookRepoName);
+    const playbookOwnerName: string = Config.getValue(ConfigValue.PlaybookOwnerName);
+    const playbookRepoName: string = Config.getValue(ConfigValue.PlaybookRepoName);
 
     Logger.log(`Getting template from ${playbookOwnerName}/${playbookRepoName} at path ${path}`);
-    await githubService.downloadRepoItem(playbookOwnerName, playbookRepoName, path, branch);
+    await repoService.downloadRepoItem(playbookOwnerName, playbookRepoName, path, branch);
   });

--- a/src/commands/commands/project/commands/init/projectInit.ts
+++ b/src/commands/commands/project/commands/init/projectInit.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "fs";
 import { Command } from "../../../../../extensions";
+import { ServiceCollection } from "../../../../../models";
 import { AgileServiceProvider, ConfigService } from "../../../../../services";
 
 export interface ProjectCreationOptions {
@@ -20,7 +21,7 @@ export const projectInit = new Command()
   .option("-u, --base-url <base-url>", "Base URL for Agile Provider project")
   .option("-p, --project <project>", "Agile provider project")
   .option("-t, --token <token>", "Agile provider access token")
-  .addAction((options: ProjectCreationOptions) => {
+  .addAction((serviceCollection: ServiceCollection, options: ProjectCreationOptions) => {
     const config = ConfigService.createInitialConfig(options);
     writeFileSync("cse.json", JSON.stringify(config, null, 4));
   });

--- a/src/extensions/command.test.ts
+++ b/src/extensions/command.test.ts
@@ -74,9 +74,9 @@ describe("Command", () => {
       myOption: optionValue,
     };
 
-    expect(action1).toBeCalledWith(expectedParsedOptions, expect.anything());
-    expect(action2).toBeCalledWith(expectedParsedOptions, expect.anything());
-    expect(action3).toBeCalledWith(expectedParsedOptions, expect.anything());
+    expect(action1).toBeCalledWith(expect.anything(), expectedParsedOptions, expect.anything());
+    expect(action2).toBeCalledWith(expect.anything(), expectedParsedOptions, expect.anything());
+    expect(action3).toBeCalledWith(expect.anything(), expectedParsedOptions, expect.anything());
   });
 
   it("prints help information", () => {

--- a/src/extensions/command.ts
+++ b/src/extensions/command.ts
@@ -1,14 +1,19 @@
 import chalk from "chalk";
 import { Command as CommanderCommand } from "commander";
 import figlet from "figlet";
-import { CseCliConfig } from "../models/config/cliConfig";
+import { createServiceCollection } from "../factories";
+import { CseCliConfig, ServiceCollection } from "../models";
 import { Link } from "../models/general/link";
 import { ConfigService } from "../services";
 import { Logger } from "../utils";
 import { urlCommand } from "./urlCommand";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ActionHandler = (options: any, config: CseCliConfig) => void | Promise<void>;
+export type ActionHandler = (
+  serviceCollection: ServiceCollection,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: any,
+  config: CseCliConfig,
+) => void | Promise<void>;
 
 export class Command extends CommanderCommand {
   private actions: ActionHandler[];
@@ -26,11 +31,13 @@ export class Command extends CommanderCommand {
   public addAction(action: ActionHandler): Command {
     this.actions.push(action);
     this.action(() => {
-      const options = this.opts();
-      const config = ConfigService.getExistingConfig();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const options: any = this.opts();
+      const config = ConfigService.getExistingConfig(options);
+      const serviceCollection = createServiceCollection(options);
 
       this.actions.forEach((action) => {
-        action(options, config);
+        action(serviceCollection, options, config);
       });
     });
     return this;

--- a/src/factories/agileServiceFactory.ts
+++ b/src/factories/agileServiceFactory.ts
@@ -10,14 +10,16 @@ export class AgileServiceFactory {
     this.registry[providerName] = service;
   }
 
-  public static get(config: AgileConfig): AgileService {
+  public static get(config?: AgileConfig): AgileService | undefined {
+    if (!config) {
+      return undefined;
+    }
+
     const { providerName } = config;
     const service = this.registry[providerName];
 
     if (!service) {
-      throw new Error(
-        `Backlog service ${providerName} not defined. Options are ${Object.keys(this.registry).join(",")}`,
-      );
+      throw new Error(`Agile service ${providerName} not defined. Options are ${Object.keys(this.registry).join(",")}`);
     }
     return new service(config);
   }

--- a/src/factories/createServiceCollection.ts
+++ b/src/factories/createServiceCollection.ts
@@ -1,0 +1,20 @@
+import { AgileServiceFactory } from "./agileServiceFactory";
+import { CseCliConfig, ServiceCollection } from "../models";
+import { GitHubRepoService, CsePlaybookService } from "../services";
+
+/**
+ * Create collection of shared services
+ *
+ * @param {CseCliConfig} config Configuration object
+ * @returns {ServiceCollection} Service Collection
+ */
+export function createServiceCollection(config: CseCliConfig): ServiceCollection {
+  const { github, agile } = config;
+  const repoService = new GitHubRepoService(github);
+
+  return {
+    agileService: AgileServiceFactory.get(agile),
+    repoService,
+    playbookService: new CsePlaybookService(repoService),
+  };
+}

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,2 +1,3 @@
 export * from "./agileServiceFactory";
+export * from "./createServiceCollection";
 export * from "./repoServiceFactory";

--- a/src/factories/repoServiceFactory.ts
+++ b/src/factories/repoServiceFactory.ts
@@ -15,9 +15,7 @@ export class RepoServiceFactory {
     const service = this.registry[providerName];
 
     if (!service) {
-      throw new Error(
-        `Backlog service ${providerName} not defined. Options are ${Object.keys(this.registry).join(",")}`,
-      );
+      throw new Error(`Repo service ${providerName} not defined. Options are ${Object.keys(this.registry).join(",")}`);
     }
     return new service(config);
   }

--- a/src/models/config/cliConfig.ts
+++ b/src/models/config/cliConfig.ts
@@ -1,9 +1,7 @@
 import { AgileConfig } from "./agile";
-import { PlaybookConfig } from "./cse";
 import { GitHubConfig } from "./github";
 
 export interface CseCliConfig {
   agile?: AgileConfig;
   github?: GitHubConfig;
-  playbook?: PlaybookConfig;
 }

--- a/src/models/config/cse/index.ts
+++ b/src/models/config/cse/index.ts
@@ -1,1 +1,0 @@
-export * from "./playbookConfig";

--- a/src/models/config/cse/playbookConfig.ts
+++ b/src/models/config/cse/playbookConfig.ts
@@ -1,4 +1,0 @@
-export interface PlaybookConfig {
-  playbookOwner?: string;
-  playbookRepo?: string;
-}

--- a/src/models/general/index.ts
+++ b/src/models/general/index.ts
@@ -1,1 +1,3 @@
 export * from "./link";
+export * from "./serviceCollection";
+export * from "./sharedOptions";

--- a/src/models/general/serviceCollection.ts
+++ b/src/models/general/serviceCollection.ts
@@ -1,0 +1,9 @@
+import { AgileService } from "../agile";
+import { PlaybookService } from "../playbook";
+import { RepoService } from "../repo";
+
+export interface ServiceCollection {
+  repoService: RepoService;
+  playbookService: PlaybookService;
+  agileService?: AgileService;
+}

--- a/src/models/general/sharedOptions.ts
+++ b/src/models/general/sharedOptions.ts
@@ -1,0 +1,4 @@
+export interface SharedOptions {
+  githubToken?: string;
+  configFile?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -2,3 +2,4 @@ export * from "./agile";
 export * from "./config";
 export * from "./general";
 export * from "./repo";
+export * from "./playbook";

--- a/src/models/playbook/index.ts
+++ b/src/models/playbook/index.ts
@@ -1,0 +1,1 @@
+export * from "./playbookService";

--- a/src/models/playbook/playbookService.ts
+++ b/src/models/playbook/playbookService.ts
@@ -1,0 +1,7 @@
+import { BacklogItemTemplate } from "../agile";
+import { RepoItem } from "../repo";
+
+export interface PlaybookService {
+  getTemplates: () => Promise<BacklogItemTemplate[]>;
+  getRepoItem: (pathInRepo: string) => Promise<RepoItem>;
+}

--- a/src/models/playbook/playbookService.ts
+++ b/src/models/playbook/playbookService.ts
@@ -3,5 +3,6 @@ import { RepoItem } from "../repo";
 
 export interface PlaybookService {
   getTemplates: () => Promise<BacklogItemTemplate[]>;
-  getRepoItem: (pathInRepo: string) => Promise<RepoItem>;
+  getRepoItem: (pathInRepo: string, includeContent?: boolean) => Promise<RepoItem>;
+  downloadRepoItem: (pathInRepo: string, localRelativePath: string) => Promise<void>;
 }

--- a/src/services/agile/providers/azureDevOps/azureDevOpsAgileService.integration.test.ts
+++ b/src/services/agile/providers/azureDevOps/azureDevOpsAgileService.integration.test.ts
@@ -1,11 +1,10 @@
 import { random } from "@supercharge/strings";
 import { ConfigValue, NumberConstants } from "../../../../constants";
-import { AgileServiceFactory } from "../../../../factories";
 import { registerProviders } from "../../../../initialization/registerProviders";
 import { BacklogItem, BacklogItemType, Sprint } from "../../../../models";
 import { Config, Logger, retryAsync, UserUtils } from "../../../../utils";
 import { AgileServiceProvider } from "../../agileServiceProvider";
-import { AzureDevOpsProviderOptions } from "./azureDevOpsAgileService";
+import { AzureDevOpsAgileService, AzureDevOpsProviderOptions } from "./azureDevOpsAgileService";
 
 describe("Azure DevOps Backlog Service", () => {
   registerProviders();
@@ -21,7 +20,7 @@ describe("Azure DevOps Backlog Service", () => {
     projectName: Config.getValue(ConfigValue.AzDOProjectName),
   };
 
-  const service = AgileServiceFactory.get({
+  const service = new AzureDevOpsAgileService({
     providerName: AgileServiceProvider.AzureDevOps,
     providerOptions,
   });

--- a/src/services/config/configService.test.ts
+++ b/src/services/config/configService.test.ts
@@ -3,10 +3,21 @@ import { CseCliConfig } from "../../models";
 import { Config } from "../../utils";
 import { AgileServiceProvider } from "../agile";
 import { ConfigService } from "./configService";
+import mockFs from "mock-fs";
+import { ModelSimulator } from "../../test";
 
 describe("Config Service", () => {
-  /* Config Service currently just stubs */
+  const existingConfig = ModelSimulator.createTestConfig();
 
+  beforeAll(() => {
+    mockFs({
+      "cse.json": JSON.stringify(existingConfig),
+    }, { createCwd: true, createTmp: true })
+  });
+
+  afterAll(() => {
+    mockFs.restore();
+  });
   it("creates initial agile config", () => {
     const now = new Date();
 
@@ -32,5 +43,41 @@ describe("Config Service", () => {
     expect(ConfigService.createInitialConfig({ agileProvider: "azdo" as AgileServiceProvider })).toEqual(
       expectedConfig,
     );
+  });
+
+  it("gets existing config with no options specified", () => {
+    expect(ConfigService.getExistingConfig()).toEqual(existingConfig);
+  });
+
+  it("gets existing config with options specified", () => {
+    const githubToken = "myToken";
+    
+    expect(ConfigService.getExistingConfig({
+      githubToken,
+    })).toEqual({
+      ...existingConfig,
+      github: {
+        personalAccessToken: githubToken
+      }
+    });
+  });
+
+  it("gets default config if config file does not exist", () => {
+    expect(ConfigService.getExistingConfig({
+      configFile: "fakeCse.json"
+    })).toEqual({});
+  });
+
+  it("gets default config with options specified if config file does not exist", () => {
+    const githubToken = "myToken";
+
+    expect(ConfigService.getExistingConfig({
+      configFile: "fakeCse.json",
+      githubToken,
+    })).toEqual({
+      github: {
+        personalAccessToken: githubToken
+      }
+    });
   });
 });

--- a/src/services/config/configService.test.ts
+++ b/src/services/config/configService.test.ts
@@ -10,9 +10,12 @@ describe("Config Service", () => {
   const existingConfig = ModelSimulator.createTestConfig();
 
   beforeAll(() => {
-    mockFs({
-      "cse.json": JSON.stringify(existingConfig),
-    }, { createCwd: true, createTmp: true })
+    mockFs(
+      {
+        "cse.json": JSON.stringify(existingConfig),
+      },
+      { createCwd: true, createTmp: true },
+    );
   });
 
   afterAll(() => {
@@ -51,33 +54,39 @@ describe("Config Service", () => {
 
   it("gets existing config with options specified", () => {
     const githubToken = "myToken";
-    
-    expect(ConfigService.getExistingConfig({
-      githubToken,
-    })).toEqual({
+
+    expect(
+      ConfigService.getExistingConfig({
+        githubToken,
+      }),
+    ).toEqual({
       ...existingConfig,
       github: {
-        personalAccessToken: githubToken
-      }
+        personalAccessToken: githubToken,
+      },
     });
   });
 
   it("gets default config if config file does not exist", () => {
-    expect(ConfigService.getExistingConfig({
-      configFile: "fakeCse.json"
-    })).toEqual({});
+    expect(
+      ConfigService.getExistingConfig({
+        configFile: "fakeCse.json",
+      }),
+    ).toEqual({});
   });
 
   it("gets default config with options specified if config file does not exist", () => {
     const githubToken = "myToken";
 
-    expect(ConfigService.getExistingConfig({
-      configFile: "fakeCse.json",
-      githubToken,
-    })).toEqual({
+    expect(
+      ConfigService.getExistingConfig({
+        configFile: "fakeCse.json",
+        githubToken,
+      }),
+    ).toEqual({
       github: {
-        personalAccessToken: githubToken
-      }
+        personalAccessToken: githubToken,
+      },
     });
   });
 });

--- a/src/services/config/configService.ts
+++ b/src/services/config/configService.ts
@@ -7,7 +7,6 @@ import { AzureDevOpsProviderOptions } from "../agile/providers";
 
 /**
  * Class dealing with the CSE configuration.
- * TODO - implement more than just stubs
  */
 export class ConfigService {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from "./agile";
 export * from "./config";
+export * from "./playbook";
 export * from "./repo";

--- a/src/services/playbook/csePlaybookService.test.ts
+++ b/src/services/playbook/csePlaybookService.test.ts
@@ -1,0 +1,74 @@
+import { ConfigValue } from "../../constants";
+import { PlaybookService, RepoItem, RepoItemType, RepoService } from "../../models";
+import { ServiceSimulator } from "../../test";
+import { Config, FileUtils } from "../../utils";
+import { CsePlaybookService } from "./csePlaybookService";
+
+describe("CSE Playbook Service", () => {
+  let repoService: RepoService;
+  let service: PlaybookService;
+
+  beforeEach(() => {
+    repoService = ServiceSimulator.createTestRepoService();
+    service = new CsePlaybookService(repoService);
+  });
+
+  it("gets templates", async () => {
+    expect((await service.getTemplates()).length).toBeTruthy();
+  });
+
+  it("gets a repo item", async () => {
+    const repoPath = "myRepoPath";
+    const expectedRepoItem: RepoItem = {
+      name: "myName",
+      path: repoPath,
+      type: RepoItemType.File,
+    };
+
+    repoService = {
+      ...ServiceSimulator.createTestRepoService(),
+      getRepoItem: jest.fn(() => Promise.resolve(expectedRepoItem)),
+    };
+    service = new CsePlaybookService(repoService);
+
+    const item = await service.getRepoItem(repoPath, true);
+
+    expect(repoService.getRepoItem).toBeCalledWith(
+      Config.getValue(ConfigValue.PlaybookOwnerName),
+      Config.getValue(ConfigValue.PlaybookRepoName),
+      repoPath,
+      true,
+    );
+    expect(item).toEqual(expectedRepoItem);
+  });
+
+  it("downloads a repo item", async () => {
+    const repoPath = "myRepoPath";
+    const content = "myContent";
+    const expectedRepoItem: RepoItem = {
+      name: "myName",
+      path: repoPath,
+      type: RepoItemType.File,
+      content,
+    };
+    const outputPath = "myOutputPath";
+
+    repoService = {
+      ...ServiceSimulator.createTestRepoService(),
+      getRepoItem: jest.fn(() => Promise.resolve(expectedRepoItem)),
+    };
+    service = new CsePlaybookService(repoService);
+
+    FileUtils.writeFile = jest.fn();
+
+    await service.downloadRepoItem(repoPath, outputPath);
+
+    expect(repoService.getRepoItem).toBeCalledWith(
+      Config.getValue(ConfigValue.PlaybookOwnerName),
+      Config.getValue(ConfigValue.PlaybookRepoName),
+      repoPath,
+      true,
+    );
+    expect(FileUtils.writeFile).toBeCalledWith(outputPath, content);
+  });
+});

--- a/src/services/playbook/csePlaybookService.ts
+++ b/src/services/playbook/csePlaybookService.ts
@@ -1,0 +1,24 @@
+import { ConfigValue } from "../../constants";
+import { BacklogItemTemplate, PlaybookService, RepoItem, RepoService } from "../../models";
+import { emptyBacklogItemTemplate, exampleBacklogItemTemplate } from "../../samples";
+import { Config } from "../../utils";
+
+export class CsePlaybookService implements PlaybookService {
+  private repoService: RepoService;
+  private playbookOwnerName: string;
+  private playbookRepoName: string;
+
+  constructor(repoService: RepoService) {
+    this.repoService = repoService;
+    this.playbookOwnerName = Config.getValue(ConfigValue.PlaybookOwnerName);
+    this.playbookRepoName = Config.getValue(ConfigValue.PlaybookRepoName);
+  }
+
+  public async getTemplates(): Promise<BacklogItemTemplate[]> {
+    return Promise.resolve([exampleBacklogItemTemplate, emptyBacklogItemTemplate]);
+  }
+
+  public async getRepoItem(pathInRepo: string, includeContent = false): Promise<RepoItem> {
+    return this.repoService.getRepoItem(this.playbookOwnerName, this.playbookRepoName, pathInRepo, includeContent);
+  }
+}

--- a/src/services/playbook/csePlaybookService.ts
+++ b/src/services/playbook/csePlaybookService.ts
@@ -1,7 +1,7 @@
 import { ConfigValue } from "../../constants";
 import { BacklogItemTemplate, PlaybookService, RepoItem, RepoService } from "../../models";
 import { emptyBacklogItemTemplate, exampleBacklogItemTemplate } from "../../samples";
-import { Config } from "../../utils";
+import { Config, FileUtils } from "../../utils";
 
 export class CsePlaybookService implements PlaybookService {
   private repoService: RepoService;
@@ -15,10 +15,20 @@ export class CsePlaybookService implements PlaybookService {
   }
 
   public async getTemplates(): Promise<BacklogItemTemplate[]> {
+    // Stub for now until we fetch templates from the repo
     return Promise.resolve([exampleBacklogItemTemplate, emptyBacklogItemTemplate]);
   }
 
   public async getRepoItem(pathInRepo: string, includeContent = false): Promise<RepoItem> {
     return this.repoService.getRepoItem(this.playbookOwnerName, this.playbookRepoName, pathInRepo, includeContent);
+  }
+
+  public async downloadRepoItem(pathInRepo: string, localRelativePath: string): Promise<void> {
+    const { content } = await this.getRepoItem(pathInRepo, true);
+    if (!content) {
+      throw new Error(`Couldn't get content from repo path ${pathInRepo}`);
+    }
+
+    FileUtils.writeFile(localRelativePath, content);
   }
 }

--- a/src/services/playbook/index.ts
+++ b/src/services/playbook/index.ts
@@ -1,0 +1,1 @@
+export * from "./csePlaybookService";

--- a/src/test/simulators/index.ts
+++ b/src/test/simulators/index.ts
@@ -1,3 +1,4 @@
 export * from "./cliSimulator";
+export * from "./serviceSimulator";
 export * from "./simulatorAgileService";
 export * from "./modelSimulator";

--- a/src/test/simulators/serviceSimulator.ts
+++ b/src/test/simulators/serviceSimulator.ts
@@ -1,0 +1,12 @@
+import { RepoService } from "../../models";
+
+export class ServiceSimulator {
+  public static createTestRepoService(): RepoService {
+    return {
+      latestCommit: jest.fn(),
+      listRepoItems: jest.fn(),
+      getRepoItem: jest.fn(),
+      downloadRepoItem: jest.fn(),
+    };
+  }
+}


### PR DESCRIPTION
- In order to allow commands to not worry about initializing the services that they need, this creates a `ServiceCollection` object that is injected into the command action.
- The `ServiceCollection` is the first param in the action call for each command
- This also allows for execution of some commands without `cse.json` being present
- Adds a `PlaybookService` interface and class, includes in the `ServiceCollection`

Also resolves #26 