### PR TITLE
ci: Updates codecov config threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project: # compare project coverage against the base of pr
       default:
         target: 75%  # min coverage ratio to be considered a success
-        threshold: 1%  # allow coverage to drop by X%
+        threshold: null  # allow coverage to drop by X%
         base: auto
     patch:  # provides an indication on how well the pull request is tested
       default:


### PR DESCRIPTION
For some reason, this `1%` threshold causes the `project` gate not to even work. This reverts it back to previous config